### PR TITLE
Add Terraform to the ops image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN apt-get update \
  && apt-get install -y python-pip curl \
  && pip install awscli
 
+RUN curl -Os https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip \
+	&& unzip terraform_0.12.24_linux_amd64.zip -d /usr/local/bin \ 
+	&& rm terraform_0.12.24_linux_amd64.zip
+
 RUN mkdir -p /tmp/app
 
 COPY ./ /tmp/app/


### PR DESCRIPTION
Rather than us all installing it in circleci, why not just add it to the ops image.