### PR TITLE
fix(tags): updating ops-cli to always include tags

### DIFF
--- a/internal/aws/ecs/ecs.go
+++ b/internal/aws/ecs/ecs.go
@@ -63,6 +63,7 @@ func (c *Client) DeployUpdate(clusterName *string, serviceName *string, imageNam
 // RegisterTaskDefinition updates the existing task definition's image.
 func (c *Client) registerTaskDefinition(task *string, images *[]string) (string, error) {
 	output, err := c.client.DescribeTaskDefinitionRequest(&ecs.DescribeTaskDefinitionInput{
+		Include: []ecs.TaskDefinitionField{ecs.TaskDefinitionFieldTags},
 		TaskDefinition: task,
 	}).Send(c.clientContext)
 


### PR DESCRIPTION
## Goals

Web repo feature deploys have been failing for a while after a first deploy with the following error:

```
panic: error registering the latest deployment, ClientException: Tags can not be empty.
	status code: 400, request id: 086d2bff-fd72-41d5-9d3e-9e422884b62f
```

This is because ops-cli needs to register a new task definition on a branch update that duplicates the original creation. AWS however during this creation will not allow an empty `tags` array. 

The command where we grab the old task via [RegisterTaskDefintion](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTaskDefinition.html) used to return Tags that were on the Task Definition by default. At some point it appears AWS changed this defintion and now it states:

```
> Determines whether to see the resource tags for the task definition. If TAGS is specified, the tags are included in the response. If this field is omitted, tags aren't included in the response.
```

To solve for this we now specifically request them